### PR TITLE
add generic AppComponent class

### DIFF
--- a/components/app_component.py
+++ b/components/app_component.py
@@ -1,0 +1,47 @@
+import dearpygui.dearpygui as gui
+
+class AppComponent:
+    def __init__(self, identifier: str) -> None:
+        self.identifier = identifier
+    
+    # Returns a dictionary with different config options.
+    def get_config(self) -> dict[str]:
+        """
+        Serializes this class's configuration into a dictionary.
+        Implementation decides what values are correct/expected.
+        """
+        return {}
+    
+    # Sets config options from the dictionary passed in.
+    def set_config(self, config: dict[str]) -> None:
+        """
+        Configures this class using `config`.
+        Implementation decides what values are correct/expected.
+        """
+        pass
+    
+    def add_config_menu(self) -> None:
+        """
+        Called by `App` to build it's config menu UI.
+
+        Should add UI widgets for configuring this class.
+        """
+        gui.add_text('No options available.')
+
+    def apply_config(self) -> None:
+        """
+        Called by `App` when 'Apply' is clicked on the config menu.
+
+        Should fetch values from this class's config menu and apply them.
+        May also save them to a file for persistence.
+        If so, the values should also be loaded in the constructor.
+        """
+        pass
+
+    def update(self) -> None:
+        """
+        Called every frame.
+
+        Any non event/callback based processing should be done here.
+        """
+        pass

--- a/data_controllers/data_controller.py
+++ b/data_controllers/data_controller.py
@@ -1,19 +1,10 @@
 import dearpygui.dearpygui as gui
+from components.app_component import AppComponent
 
-class DataController:
+class DataController(AppComponent):
     """
     Generic data controller class for reading/writing to a port/connection.
     """
-
-    def __init__(self, identifier: str) -> None:
-        """
-        Constructor.
-
-        `identifier` - A string prefix that will be used for UI widget tags.
-        Must be unique across class instances.
-        """
-        self.identifier = identifier
-        pass
     
     # Raise when we can't open().
     class DataControllerException(Exception):
@@ -21,40 +12,6 @@ class DataController:
         Generic exception for DataController so people using it know what to catch.
 
         This is usually raised when DataController.open() fails.
-        """
-        pass
-
-    # Returns a dictionary with different config options.
-    def get_config(self) -> dict[str]:
-        """
-        Serializes this class's configuration into a dictionary.
-        Implementation decides what values are correct/expected.
-        """
-        return {}
-    
-    # Sets config options from the dictionary passed in.
-    def set_config(self, config: dict[str]) -> None:
-        """
-        Configures this class using `config`.
-        Implementation decides what values are correct/expected.
-        """
-        pass
-    
-    def add_config_menu(self) -> None:
-        """
-        Called by `App` to build it's config menu UI.
-
-        Should add UI widgets for configuring this class.
-        """
-        gui.add_text('No options available.')
-    
-    def apply_config(self) -> None:
-        """
-        Called by `App` when 'Apply' is clicked on the config menu.
-
-        Should fetch values from this class's config menu and apply them.
-        May also save them to a file for persistence.
-        If so, the values should also be loaded in the constructor.
         """
         pass
     
@@ -76,10 +33,3 @@ class DataController:
         """
         pass
 
-    def update(self) -> None:
-        """
-        Called every frame.
-
-        Any non event/callback based processing should be done here.
-        """
-        pass


### PR DESCRIPTION
So adding new "components" doesn't become a duck-typing pain. This gives us a sort of universal API for components to extend.

Main features:
- `update()` function
- `get_config()`, `set_config()`, `apply_config()`, etc. configuration functions. Default implementation does nothing and if your component doesn't need to be configured you don't need to worry about it.
- `self.identifier` string, which is passed to the constructor and is suppose to be unique to each instance of the class. This is used both to save instance-specific configs and to prefix the tag names of UI elements. The latter lets us have UI elements with constant names that are still unique between class instances.

Changes:
- Added `AppComponent` class
- Made `DataController` inherit from `AppComponent`