### PR TITLE
add global tabs that other components can add stuff to

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ class App:
     # Widget tags
     TAG_MAIN_WINDOW = 'app.main_window'
     TAG_MAIN_MENU = 'app.main_menu'
+    TAG_MAIN_TAB_BAR = 'app.main_tab_bar'
     TAG_CONFIG_WINDOW = 'app.config_window'
 
     def __init__(self) -> None:
@@ -42,6 +43,9 @@ class App:
                 with gui.menu(label='Help'):
                     gui.add_menu_item(label='Docs', callback=None)
                     gui.add_menu_item(label='About', callback=None)
+            
+            gui.add_tab_bar(tag=App.TAG_MAIN_TAB_BAR)
+
             gui.set_primary_window(App.TAG_MAIN_WINDOW, True)
             self.grapher = Grapher('grapher', self.iliad)
 
@@ -80,7 +84,7 @@ class App:
         Calls `update()` on all components.
         """
         self.iliad.update()
-        self.grapher.update()
+        # self.grapher.update()
 
     def run(self) -> None:
         """

--- a/app.py
+++ b/app.py
@@ -84,7 +84,7 @@ class App:
         Calls `update()` on all components.
         """
         self.iliad.update()
-        # self.grapher.update()
+        self.grapher.update()
 
     def run(self) -> None:
         """

--- a/data_controllers/iliad_data_controller.py
+++ b/data_controllers/iliad_data_controller.py
@@ -12,7 +12,7 @@ class IliadDataController(serial_data_controller.SerialDataController):
         super().__init__(identifier)
 
         # Create a gui for opening / closing the connection
-        with gui.window(label='Telemetry Connection'):
+        with gui.tab(label='Telemetry Connection', parent='app.main_tab_bar'):
             with gui.group(horizontal=True):
                 gui.add_text('DISCONNECTED', tag=f'{self.identifier}.connection.status')
                 gui.add_button(label='CONNECT', tag=f'{self.identifier}.connection.connect', callback=lambda: self._on_connect_button_clicked())

--- a/grapher/grapher.py
+++ b/grapher/grapher.py
@@ -205,25 +205,26 @@ class Grapher(AppComponent):
         # Store a reference to the IliadDataController so we can get data from it later.
         self.iliad = iliad
 
-        with gui.group(horizontal=True):
+        with gui.tab(label='Telemetry', parent='app.main_tab_bar'):
+            with gui.group(horizontal=True):
 
-            # Create the gui stuff:
-            with gui.group(horizontal=False):
-                displaySidebar()
-            
-            with gui.group(horizontal=False):
-                with gui.tab_bar() as tb:
-                    # with gui.tab_bar(pos=(100, 100)) as tb:
-                    #tracking tab
-                    displayTracking()
-                    #arming tab
-                    displayArming()
-                    #health tab
-                    displayHealth()
-                    #packets tab
-                    displayPackets()
-                    #recovery tab
-                    displayRecovery()
+                # Create the gui stuff:
+                with gui.group(horizontal=False):
+                    displaySidebar()
+                
+                with gui.group(horizontal=False):
+                    with gui.tab_bar() as tb:
+                        # with gui.tab_bar(pos=(100, 100)) as tb:
+                        #tracking tab
+                        displayTracking()
+                        #arming tab
+                        displayArming()
+                        #health tab
+                        displayHealth()
+                        #packets tab
+                        displayPackets()
+                        #recovery tab
+                        displayRecovery()
         
 
     

--- a/iliad/arm_control.py
+++ b/iliad/arm_control.py
@@ -12,7 +12,7 @@ class ArmControl(AppComponent):
         self.is_srad_fc_armed = False
         self.is_cots_fc_armed = False
 
-        with gui.window(label='Arm Control'):
+        with gui.tab(label='Arm Control', parent='app.main_tab_bar'):
             with gui.group(horizontal=True):
                 gui.add_text('DISARMED', tag=f'{self.identifier}.camera.status')
                 gui.add_button(label='ARM', tag=f'{self.identifier}.camera.arm', callback=lambda: self.arm_camera())

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ import dearpygui.dearpygui as gui
 from app import App
 
 if __name__ == '__main__':
-
     app = App()
     app.run()
     

--- a/tests/iliad_data_controller_test.py
+++ b/tests/iliad_data_controller_test.py
@@ -12,6 +12,8 @@ def start_headless_gui() -> None:
     gui.create_context()
     gui.create_viewport(title='Iliad Ground Control', width=600, height=300)
     gui.setup_dearpygui()
+    with gui.window():
+        gui.add_tab_bar(tag='app.main_tab_bar')
 
 def stop_headless_gui() -> None:
     gui.destroy_context()

--- a/tests/iliad_data_controller_test.py
+++ b/tests/iliad_data_controller_test.py
@@ -4,10 +4,21 @@ import utils.math_util as math_util
 import serial
 import math
 import pytest
+import dearpygui.dearpygui as gui
 
 # TODO: Don't hardcode port values. Maybe make virtual linked ports?
 
+def start_headless_gui() -> None:
+    gui.create_context()
+    gui.create_viewport(title='Iliad Ground Control', width=600, height=300)
+    gui.setup_dearpygui()
+
+def stop_headless_gui() -> None:
+    gui.destroy_context()
+
+
 def test_update():
+    start_headless_gui()
     test = IliadDataController('test')
     config = {
         'port_name': 'COM2',
@@ -21,6 +32,7 @@ def test_update():
     for i in range(1000):
         test.update()
     test.close()
+    stop_headless_gui()
 
 def setup_packet_test() -> tuple[IliadDataController, serial.Serial]:
     """
@@ -58,6 +70,7 @@ def setup_packet_test() -> tuple[IliadDataController, serial.Serial]:
     ]
 )
 def test_arm_status_packet(timestamp: float, status_1: bool, status_2: bool, status_3: bool):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_ARM_STATUS, timestamp, (status_1, status_2, status_3)))
     for i in range(100):
@@ -70,6 +83,7 @@ def test_arm_status_packet(timestamp: float, status_1: bool, status_2: bool, sta
     assert test.arm_status_3_data.y_data[0] == status_3
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, altitude_1, altitude_2",
@@ -80,6 +94,7 @@ def test_arm_status_packet(timestamp: float, status_1: bool, status_2: bool, sta
     ]
 )
 def test_altitude_packet(timestamp: float, altitude_1: float, altitude_2: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_ALTITUDE, timestamp, (altitude_1, altitude_2)))
     for i in range(100):
@@ -90,6 +105,7 @@ def test_altitude_packet(timestamp: float, altitude_1: float, altitude_2: float)
     assert math_util.is_list_close(test.altitude_2_data.y_data, [altitude_2])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, acceleration_x, acceleration_y, acceleration_z",
@@ -100,6 +116,7 @@ def test_altitude_packet(timestamp: float, altitude_1: float, altitude_2: float)
     ]
 )
 def test_acceleration_packet(timestamp: float, acceleration_x: float, acceleration_y: float, acceleration_z: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_ACCELERATION, timestamp, (acceleration_x, acceleration_y, acceleration_z)))
     for i in range(100):
@@ -112,6 +129,7 @@ def test_acceleration_packet(timestamp: float, acceleration_x: float, accelerati
     assert math_util.is_list_close(test.acceleration_z_data.y_data, [acceleration_z])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, latitude, longitude",
@@ -122,6 +140,7 @@ def test_acceleration_packet(timestamp: float, acceleration_x: float, accelerati
     ]
 )
 def test_gps_coordinate_packet(timestamp: float, latitude: float, longitude: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_COORDINATES, timestamp, (latitude, longitude)))
     for i in range(100):
@@ -132,6 +151,7 @@ def test_gps_coordinate_packet(timestamp: float, latitude: float, longitude: flo
     assert math_util.is_list_close(test.gps_longitude_data.y_data, [longitude])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, temp_1, temp_2, temp_3, temp_4",
@@ -142,6 +162,7 @@ def test_gps_coordinate_packet(timestamp: float, latitude: float, longitude: flo
     ]
 )
 def test_board_temperature_packet(timestamp: float, temp_1: float, temp_2: float, temp_3: float, temp_4: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_BOARD_TEMPERATURE, timestamp, (temp_1, temp_2, temp_3, temp_4)))
     for i in range(100):
@@ -156,6 +177,7 @@ def test_board_temperature_packet(timestamp: float, temp_1: float, temp_2: float
     assert math_util.is_list_close(test.board_4_temperature_data.y_data, [temp_4])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, voltage_1, voltage_2, voltage_3, voltage_4",
@@ -166,6 +188,7 @@ def test_board_temperature_packet(timestamp: float, temp_1: float, temp_2: float
     ]
 )
 def test_board_voltage_packet(timestamp: float, voltage_1: float, voltage_2: float, voltage_3: float, voltage_4: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_BOARD_VOLTAGE, timestamp, (voltage_1, voltage_2, voltage_3, voltage_4)))
     for i in range(100):
@@ -180,6 +203,7 @@ def test_board_voltage_packet(timestamp: float, voltage_1: float, voltage_2: flo
     assert math_util.is_list_close(test.board_4_voltage_data.y_data, [voltage_4])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, current_1, current_2, current_3, current_4",
@@ -190,6 +214,7 @@ def test_board_voltage_packet(timestamp: float, voltage_1: float, voltage_2: flo
     ]
 )
 def test_board_current_packet(timestamp: float, current_1: float, current_2: float, current_3: float, current_4: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_BOARD_CURRENT, timestamp, (current_1, current_2, current_3, current_4)))
     for i in range(100):
@@ -204,6 +229,7 @@ def test_board_current_packet(timestamp: float, current_1: float, current_2: flo
     assert math_util.is_list_close(test.board_4_current_data.y_data, [current_4])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, voltage_1, voltage_2, voltage_3",
@@ -214,6 +240,7 @@ def test_board_current_packet(timestamp: float, current_1: float, current_2: flo
     ]
 )
 def test_battery_voltage_packet(timestamp: float, voltage_1: float, voltage_2: float, voltage_3: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_BATTERY_VOLTAGE, timestamp, (voltage_1, voltage_2, voltage_3)))
     for i in range(100):
@@ -226,6 +253,7 @@ def test_battery_voltage_packet(timestamp: float, voltage_1: float, voltage_2: f
     assert math_util.is_list_close(test.battery_3_voltage_data.y_data, [voltage_3])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, magnetometer_1, magnetometer_2, magnetometer_3",
@@ -236,6 +264,7 @@ def test_battery_voltage_packet(timestamp: float, voltage_1: float, voltage_2: f
     ]
 )
 def test_magnetometer_packet(timestamp: float, magnetometer_1: float, magnetometer_2: float, magnetometer_3: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_MAGNETOMETER, timestamp, (magnetometer_1, magnetometer_2, magnetometer_3)))
     for i in range(100):
@@ -248,6 +277,7 @@ def test_magnetometer_packet(timestamp: float, magnetometer_1: float, magnetomet
     assert math_util.is_list_close(test.magnetometer_data_3.y_data, [magnetometer_3])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, gyroscope_x, gyroscope_y, gyroscope_z",
@@ -258,6 +288,7 @@ def test_magnetometer_packet(timestamp: float, magnetometer_1: float, magnetomet
     ]
 )
 def test_gyroscope_packet(timestamp: float, gyroscope_x: float, gyroscope_y: float, gyroscope_z: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GYROSCOPE, timestamp, (gyroscope_x, gyroscope_y, gyroscope_z)))
     for i in range(100):
@@ -270,6 +301,7 @@ def test_gyroscope_packet(timestamp: float, gyroscope_x: float, gyroscope_y: flo
     assert math_util.is_list_close(test.gyroscope_z_data.y_data, [gyroscope_z])
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, satellites",
@@ -280,6 +312,7 @@ def test_gyroscope_packet(timestamp: float, gyroscope_x: float, gyroscope_y: flo
     ]
 )
 def test_gps_satellites_packet(timestamp: float, satellites: int):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_SATELLITES, timestamp, (satellites,)))
     for i in range(100):
@@ -288,6 +321,7 @@ def test_gps_satellites_packet(timestamp: float, satellites: int):
     assert test.gps_satellites_data.y_data == [satellites]
     test.close()
     port.close()
+    stop_headless_gui()
 
 @pytest.mark.parametrize(
     "timestamp, speed",
@@ -298,6 +332,7 @@ def test_gps_satellites_packet(timestamp: float, satellites: int):
     ]
 )
 def test_gps_ground_speed_packet(timestamp: float, speed: float):
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, timestamp, (speed,)))
     for i in range(100):
@@ -306,8 +341,10 @@ def test_gps_ground_speed_packet(timestamp: float, speed: float):
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [speed])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_multiple_packets():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (123.456,)))
@@ -318,8 +355,10 @@ def test_multiple_packets():
     math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456, 123.456, 123.456])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_mixed_packets():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(
         packet_util.PACKET_TYPE_GPS_SATELLITES + packet_util.PACKET_TYPE_GPS_GROUND_SPEED,
@@ -333,8 +372,10 @@ def test_mixed_packets():
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_resync_on_corrupted_packet():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (789.012,)))
@@ -407,8 +448,10 @@ def test_resync_on_corrupted_packet():
     ])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_resync_speed():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (789.012,)))
@@ -422,8 +465,10 @@ def test_resync_speed():
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456, 789.012, 901.234])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_resync_on_corrupted_header():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (789.012,)))
@@ -437,8 +482,10 @@ def test_resync_on_corrupted_header():
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456, 789.012, 901.234])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_resync_on_corrupted_body():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (789.012,)))
@@ -452,8 +499,10 @@ def test_resync_on_corrupted_body():
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456, 789.012, 901.234])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_resync_on_double_corrupted_head():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (789.012,)))
@@ -470,8 +519,10 @@ def test_resync_on_double_corrupted_head():
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456, 789.012, 901.234])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_resync_on_double_corrupted_body():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (789.012,)))
@@ -488,8 +539,10 @@ def test_resync_on_double_corrupted_body():
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456, 789.012, 901.234])
     test.close()
     port.close()
+    stop_headless_gui()
 
 def test_resync_on_double_corrupted_mixed():
+    start_headless_gui()
     (test, port) = setup_packet_test()
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.0, (123.456,)))
     port.write(packet_util.create_packet(packet_util.PACKET_TYPE_GPS_GROUND_SPEED, 0.1, (789.012,)))
@@ -506,3 +559,4 @@ def test_resync_on_double_corrupted_mixed():
     assert math_util.is_list_close(test.gps_ground_speed_data.y_data, [123.456, 789.012, 901.234])
     test.close()
     port.close()
+    stop_headless_gui()

--- a/tests/test_arm_control.py
+++ b/tests/test_arm_control.py
@@ -25,6 +25,8 @@ def test_receive_arm_status(camera_status: bool, srad_fc_status: bool, cots_fc_s
     gui.create_context()
     gui.create_viewport(title='Iliad Ground Control', width=600, height=300)
     gui.setup_dearpygui()
+    with gui.window():
+        gui.add_tab_bar(tag='app.main_tab_bar')
 
     # Get ArmControl instance
     iliad = IliadDataController('test_iliad')
@@ -106,6 +108,8 @@ def test_receive_multiple_arm_status(arm_statuses: list[tuple[bool, bool, bool]]
     gui.create_context()
     gui.create_viewport(title='Iliad Ground Control', width=600, height=300)
     gui.setup_dearpygui()
+    with gui.window():
+        gui.add_tab_bar(tag='app.main_tab_bar')
 
     # Get ArmControl instance
     iliad = IliadDataController('test_iliad')
@@ -151,6 +155,8 @@ def test_receive_no_arm_status() -> None:
     gui.create_context()
     gui.create_viewport(title='Iliad Ground Control', width=600, height=300)
     gui.setup_dearpygui()
+    with gui.window():
+        gui.add_tab_bar(tag='app.main_tab_bar')
 
     # Get ArmControl instance
     iliad = IliadDataController('test_iliad')


### PR DESCRIPTION
Adds a global tab bar in `App` that other components can add tabs to.

`IlliadDataController` and `ArmControl` create dearpygui GUI components in their constructors, so we either need to implement a "headless mode" for them or create a headless dearpygui instance in every test. I've done the latter, but the former is probably better in the long run. Depending on how things go, shouldn't be too hard to switch over.